### PR TITLE
Fix ROS1 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,7 +238,6 @@ if(DEFINED ENV{ROS_VERSION})
     catkin_package(
       INCLUDE_DIRS include
       LIBRARIES ${glim_LIBRARIES} ${GTSAM_LIBRARIES} fmt spdlog::spdlog
-      CFG_EXTRAS "glim-config.cmake"
     )
     install(DIRECTORY config DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
   endif()

--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
   <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
 
   <export>
+    <build_type condition="$ROS_VERSION == 1">catkin</build_type>
     <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
   </export>
 </package>


### PR DESCRIPTION
CFG_EXTRAS causes cmake include errors when both `glim` and `glim_ros1` are placed in the same catkin_ws.