### PR TITLE
reduce memory footprint

### DIFF
--- a/config/config_ros.json
+++ b/config/config_ros.json
@@ -3,6 +3,8 @@
     // Backend modules
     "enable_local_mapping": true,
     "enable_global_mapping": true,
+    // Points config
+    "keep_raw_points": false,
     // IMU config
     "imu_time_offset": 0.0,
     "acc_scale": 1.0,

--- a/config/config_sub_mapping_gpu.json
+++ b/config/config_sub_mapping_gpu.json
@@ -23,6 +23,7 @@
   // --- Post processing ---
   // submap_downsample_resolution   : Resolution of voxel grid downsampling for created submaps
   // submap_voxel_resolution        : [deprecated] Resolution of VGICP voxels for created submaps (used in global mapping)
+  // submap_target_num_points       : Downsampling target number of points for created submaps (disabled when < 0)
   */
   "sub_mapping": {
     "so_name": "libsub_mapping.so",
@@ -46,6 +47,7 @@
     "keyframe_voxelmap_scaling_factor": 2.0,
     // Post processing
     "submap_downsample_resolution": 0.1,
-    "submap_voxel_resolution": 0.5
+    "submap_voxel_resolution": 0.5,
+    "submap_target_num_points": 50000
   }
 }

--- a/config/config_sub_mapping_passthrough.json
+++ b/config/config_sub_mapping_passthrough.json
@@ -14,6 +14,7 @@
   // submap_voxel_resolution      : Resolution of submap voxels for downsampling
   // min_dist_in_voxel            : Minimum distance between points in a voxel
   // max_num_points_in_voxel      : Maximum number of points in a voxel
+  // submap_target_num_points     : Final target number of points for a submap (disabled when < 0)
   */
   "sub_mapping": {
     "so_name": "libsub_mapping_passthrough.so",
@@ -27,6 +28,7 @@
     // Submap creation params
     "submap_voxel_resolution": 0.5,
     "min_dist_in_voxel": 0.2,
-    "max_num_points_in_voxel": 100
+    "max_num_points_in_voxel": 100,
+    "submap_target_num_points": 50000
   }
 }

--- a/include/glim/mapping/global_mapping.hpp
+++ b/include/glim/mapping/global_mapping.hpp
@@ -92,7 +92,7 @@ private:
   std::any stream_buffer_roundrobin;
 
   std::vector<SubMap::Ptr> submaps;
-  std::vector<gtsam_points::PointCloud::Ptr> subsampled_submaps;
+  std::vector<gtsam_points::PointCloud::ConstPtr> subsampled_submaps;
 
   std::unique_ptr<gtsam::Values> new_values;
   std::unique_ptr<gtsam::NonlinearFactorGraph> new_factors;

--- a/include/glim/mapping/sub_mapping.hpp
+++ b/include/glim/mapping/sub_mapping.hpp
@@ -49,6 +49,7 @@ public:
 
   double submap_downsample_resolution;
   double submap_voxel_resolution;
+  int submap_target_num_points;
 };
 
 /**

--- a/include/glim/mapping/sub_mapping_passthrough.hpp
+++ b/include/glim/mapping/sub_mapping_passthrough.hpp
@@ -29,6 +29,7 @@ public:
   int max_num_voxels;
   double adaptive_max_num_voxels;
 
+  int submap_target_num_points;
   double submap_voxel_resolution;
   double min_dist_in_voxel;
   int max_num_points_in_voxel;

--- a/src/glim/mapping/global_mapping.cpp
+++ b/src/glim/mapping/global_mapping.cpp
@@ -240,7 +240,7 @@ void GlobalMapping::insert_submap(int current, const SubMap::Ptr& submap) {
     for (int i = 0; i < params.submap_voxelmap_levels; i++) {
       const double resolution = params.submap_voxel_resolution * std::pow(params.submap_voxelmap_scaling_factor, i);
       auto voxelmap = std::make_shared<gtsam_points::GaussianVoxelMapGPU>(resolution);
-      voxelmap->insert(*subsampled_submap);
+      voxelmap->insert(*submap->frame);
       submap->voxelmaps.push_back(voxelmap);
     }
   }

--- a/src/glim/mapping/global_mapping.cpp
+++ b/src/glim/mapping/global_mapping.cpp
@@ -218,7 +218,12 @@ void GlobalMapping::insert_submap(const SubMap::Ptr& submap) {
 void GlobalMapping::insert_submap(int current, const SubMap::Ptr& submap) {
   submap->voxelmaps.clear();
 
-  gtsam_points::PointCloud::Ptr subsampled_submap = gtsam_points::random_sampling(submap->frame, params.randomsampling_rate, mt);
+  gtsam_points::PointCloud::ConstPtr subsampled_submap;
+  if (params.randomsampling_rate > 0.99) {
+    subsampled_submap = submap->frame;
+  } else {
+    subsampled_submap = gtsam_points::random_sampling(submap->frame, params.randomsampling_rate, mt);
+  }
 
 #ifdef BUILD_GTSAM_POINTS_GPU
   if (params.enable_gpu && !submap->frame->points_gpu) {
@@ -226,7 +231,11 @@ void GlobalMapping::insert_submap(int current, const SubMap::Ptr& submap) {
   }
 
   if (params.enable_gpu) {
-    subsampled_submap = gtsam_points::PointCloudGPU::clone(*subsampled_submap);
+    if (params.randomsampling_rate > 0.99) {
+      subsampled_submap = submap->frame;
+    } else {
+      subsampled_submap = gtsam_points::PointCloudGPU::clone(*subsampled_submap);
+    }
 
     for (int i = 0; i < params.submap_voxelmap_levels; i++) {
       const double resolution = params.submap_voxel_resolution * std::pow(params.submap_voxelmap_scaling_factor, i);

--- a/src/glim/mapping/sub_mapping.cpp
+++ b/src/glim/mapping/sub_mapping.cpp
@@ -463,7 +463,6 @@ SubMap::Ptr SubMapping::create_submap(bool force_create) const {
   }
   logger->debug("|merged_submap|={}", submap->frame->size());
 
-
   return submap;
 }
 

--- a/src/glim/mapping/sub_mapping.cpp
+++ b/src/glim/mapping/sub_mapping.cpp
@@ -58,6 +58,7 @@ SubMappingParams::SubMappingParams() {
 
   submap_downsample_resolution = config.param<double>("sub_mapping", "submap_downsample_resolution", 0.25);
   submap_voxel_resolution = config.param<double>("sub_mapping", "submap_voxel_resolution", 0.5);
+  submap_target_num_points = config.param<int>("sub_mapping", "submap_target_num_points", -1);
 
   enable_gpu = false;
   if (registration_error_factor_type.find("GPU") != std::string::npos) {
@@ -462,6 +463,12 @@ SubMap::Ptr SubMapping::create_submap(bool force_create) const {
     submap->frame = gtsam_points::merge_frames_auto(poses_to_merge, keyframes_to_merge, params.submap_downsample_resolution);
   }
   logger->debug("|merged_submap|={}", submap->frame->size());
+
+  if (params.submap_target_num_points > 0 && submap->frame->size() > params.submap_target_num_points) {
+    std::mt19937 mt(submap_count * 643145 + submap->frame->size() * 4312);  // Just a random-like seed
+    submap->frame = gtsam_points::random_sampling(submap->frame, static_cast<double>(params.submap_target_num_points) / submap->frame->size(), mt);
+    logger->debug("|subsampled_submap|={}", submap->frame->size());
+  }
 
   return submap;
 }


### PR DESCRIPTION
- Avoid redundant submap data copy (resident mem reduced from 4 GB -> 2.5GB for `os1_128_01`).
- Regulate the maximum number of points in a submap (2.5 GB -> 1.4 GB)