### PR TITLE
Fix indeterminant linear system

### DIFF
--- a/include/glim/util/extension_module.hpp
+++ b/include/glim/util/extension_module.hpp
@@ -23,6 +23,11 @@ public:
   virtual bool ok() const { return true; }
 
   /**
+   * @brief Called when the system is quitting.
+   */
+  virtual void at_exit(const std::string& dump_path) {}
+
+  /**
    * @brief Load an extension module from a dynamic library
    * @param so_name  Dynamic library name
    * @return         Loaded extension module

--- a/include/glim/viewer/standard_viewer.hpp
+++ b/include/glim/viewer/standard_viewer.hpp
@@ -79,6 +79,9 @@ private:
   std::vector<std::pair<boost::weak_ptr<gtsam::NonlinearFactor>, FactorLineGetter>> odometry_factor_lines;
   std::unordered_map<std::uint64_t, Eigen::Isometry3f> odometry_poses;
 
+  bool show_mapping_tools;
+  float min_overlap;
+
   double point_size;
   bool point_size_metric;
   bool point_shape_circle;

--- a/src/glim/viewer/standard_viewer.cpp
+++ b/src/glim/viewer/standard_viewer.cpp
@@ -59,6 +59,9 @@ StandardViewer::StandardViewer() : logger(create_module_logger("viewer")) {
   z_range = config.param("standard_viewer", "default_z_range", Eigen::Vector2d(-2.0, 4.0)).cast<float>();
   auto_z_range << 0.0f, 0.0f;
 
+  show_mapping_tools = false;
+  min_overlap = 0.2f;
+
   points_alpha = config.param("standard_viewer", "points_alpha", 1.0);
   factors_alpha = config.param("standard_viewer", "factors_alpha", 1.0);
 
@@ -730,6 +733,11 @@ void StandardViewer::drawable_selection() {
     show_submaps = show_factors = show_mapping;
   }
 
+  ImGui::SameLine();
+  if (ImGui::Button("Tools")) {
+    show_mapping_tools = true;
+  }
+
   ImGui::Checkbox("submaps", &show_submaps);
   ImGui::SameLine();
   ImGui::Checkbox("factors", &show_factors);
@@ -748,6 +756,21 @@ void StandardViewer::drawable_selection() {
     ImGui::Text("stamp:%.3f ~ %.3f", last_point_stamps.first, last_point_stamps.second);
     ImGui::Text("vel:%.3f %.3f %.3f", last_imu_vel[0], last_imu_vel[1], last_imu_vel[2]);
     ImGui::Text("bias:%.3f %.3f %.3f %.3f %.3f %.3f", last_imu_bias[0], last_imu_bias[1], last_imu_bias[2], last_imu_bias[3], last_imu_bias[4], last_imu_bias[5]);
+    ImGui::End();
+  }
+
+  if (show_mapping_tools) {
+    ImGui::Begin("mapping tools", &show_mapping_tools, ImGuiWindowFlags_AlwaysAutoResize);
+    ImGui::DragFloat("Min overlap", &min_overlap, 0.01f, 0.01f, 1.0f);
+    if (ImGui::Button("Find overlapping submaps")) {
+      logger->info("finding overlapping submaps...");
+      GlobalMappingCallbacks::request_to_find_overlapping_submaps(min_overlap);
+    }
+
+    if (ImGui::Button("Optimize")) {
+      logger->info("optimizing...");
+      GlobalMappingCallbacks::request_to_optimize();
+    }
     ImGui::End();
   }
 }


### PR DESCRIPTION
- Fix the graph when an indeterminant linear system is detected by inserting a damping factor and resetting the smoother.
- Add a few optimization tools to the standard viewer.