### PR TITLE
use squaredNorm() in loops where applicable for some cpu savings

### DIFF
--- a/src/glim/mapping/global_mapping.cpp
+++ b/src/glim/mapping/global_mapping.cpp
@@ -304,6 +304,8 @@ void GlobalMapping::find_overlapping_submaps(double min_overlap) {
   }
 
   gtsam::NonlinearFactorGraph new_factors;
+  
+  double squared_max_implicit_loop_distance = params.max_implicit_loop_distance * params.max_implicit_loop_distance;
 
   for (int i = 0; i < submaps.size(); i++) {
     for (int j = i + 1; j < submaps.size(); j++) {
@@ -312,8 +314,8 @@ void GlobalMapping::find_overlapping_submaps(double min_overlap) {
       }
 
       const Eigen::Isometry3d delta = submaps[i]->T_world_origin.inverse() * submaps[j]->T_world_origin;
-      const double dist = delta.translation().norm();
-      if (dist > params.max_implicit_loop_distance) {
+      const double squared_dist = delta.translation().squaredNorm();
+      if (squared_dist > squared_max_implicit_loop_distance) {
         continue;
       }
 
@@ -432,9 +434,11 @@ boost::shared_ptr<gtsam::NonlinearFactorGraph> GlobalMapping::create_matching_co
   const auto& current_submap = submaps.back();
 
   double previous_overlap = 0.0;
+  double squared_max_implicit_loop_distance = params.max_implicit_loop_distance * params.max_implicit_loop_distance;
+  
   for (int i = 0; i < current; i++) {
-    const double dist = (submaps[i]->T_world_origin.translation() - current_submap->T_world_origin.translation()).norm();
-    if (dist > params.max_implicit_loop_distance) {
+    const double squared_dist = (submaps[i]->T_world_origin.translation() - current_submap->T_world_origin.translation()).squaredNorm();
+    if (squared_dist > squared_max_implicit_loop_distance) {
       continue;
     }
 

--- a/src/glim/preprocess/cloud_preprocessor.cpp
+++ b/src/glim/preprocess/cloud_preprocessor.cpp
@@ -92,10 +92,13 @@ PreprocessedFrame::Ptr CloudPreprocessor::preprocess_impl(const RawPoints::Const
   // Distance filter
   std::vector<int> indices;
   indices.reserve(frame->size());
+  double squared_distance_near_thresh = params.distance_near_thresh * params.distance_near_thresh;
+  double squared_distance_far_thresh  = params.distance_far_thresh  * params.distance_far_thresh;
+  
   for (int i = 0; i < frame->size(); i++) {
     const bool is_finite = frame->points[i].allFinite();
-    const double dist = (Eigen::Vector4d() << frame->points[i].head<3>(), 0.0).finished().norm();
-    if (dist > params.distance_near_thresh && dist < params.distance_far_thresh && is_finite) {
+    const double squared_dist = (Eigen::Vector4d() << frame->points[i].head<3>(), 0.0).finished().squaredNorm()();
+    if (squared_dist > squared_distance_near_thresh && dist < squared_distance_far_thresh && is_finite) {
       indices.push_back(i);
     }
   }

--- a/src/glim/preprocess/cloud_preprocessor.cpp
+++ b/src/glim/preprocess/cloud_preprocessor.cpp
@@ -97,8 +97,8 @@ PreprocessedFrame::Ptr CloudPreprocessor::preprocess_impl(const RawPoints::Const
   
   for (int i = 0; i < frame->size(); i++) {
     const bool is_finite = frame->points[i].allFinite();
-    const double squared_dist = (Eigen::Vector4d() << frame->points[i].head<3>(), 0.0).finished().squaredNorm()();
-    if (squared_dist > squared_distance_near_thresh && dist < squared_distance_far_thresh && is_finite) {
+    const double squared_dist = (Eigen::Vector4d() << frame->points[i].head<3>(), 0.0).finished().squaredNorm();
+    if (squared_dist > squared_distance_near_thresh && squared_dist < squared_distance_far_thresh && is_finite) {
       indices.push_back(i);
     }
   }


### PR DESCRIPTION
This changes places where `norm()` is computed in loops to use `squaredNorm()` instead and compare against the squared threshold, avoiding a large number of sqrt computations that are not really needed. Maybe not significant in the grand scheme of things, but a rather low hanging fruit optimization opportunity.