### PR TITLE
add rosdep keys for dependencies and use system GTSAM package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ target_link_libraries(glim
   Boost::boost
   Boost::serialization
   Eigen3::Eigen
-  GTSAM::GTSAM
+  gtsam
   gtsam_points::gtsam_points
   OpenMP::OpenMP_CXX
   spdlog::spdlog

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,7 +235,7 @@ if(DEFINED ENV{ROS_VERSION})
     install(DIRECTORY config DESTINATION share/glim)
     ament_export_include_directories(include ${EIGEN3_INCLUDE_DIR} ${OpenCV_INCLUDE_DIRS})
     ament_export_libraries(${glim_LIBRARIES} ${GTSAM_LIBRARIES} fmt spdlog::spdlog)
-    ament_export_interfaces(glim-targets HAS_LIBRARY_TARGET)
+    ament_export_targets(glim-targets HAS_LIBRARY_TARGET)
     ament_package(CONFIG_EXTRAS "cmake/glim-config.cmake.in")
   elseif($ENV{ROS_VERSION} EQUAL 1)
     # ROS1

--- a/package.xml
+++ b/package.xml
@@ -9,6 +9,9 @@
 
   <depend>fmt</depend>
   <depend>spdlog</depend>
+  <depend>gtsam</depend>
+  <depend>gtsam_points</depend>
+  <depend>iridescence</depend>
 
   <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
   <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>


### PR DESCRIPTION
Similar to https://github.com/koide3/gtsam_points/pull/52 and https://github.com/koide3/iridescence/pull/162, this adds rosdep keys for dependencies, including GTSAM, to simplify the building in a colcon workspace.