### PR TITLE
Prevent possible segmentation fault

### DIFF
--- a/src/glim/mapping/sub_map.cpp
+++ b/src/glim/mapping/sub_map.cpp
@@ -141,6 +141,11 @@ SubMap::Ptr SubMap::load(const std::string& path) {
 
   auto frame = gtsam_points::PointCloudCPU::load(path);
 
+  if (!frame) {
+    spdlog::error("failed to load frame from {}", path);
+    return nullptr;
+  }
+
   if (frame->size()) {
     const auto valid_point = [](const Eigen::Vector4d& p) { return std::abs(p.w() - 1.0) < 1e-3 && p.head<3>().allFinite(); };
     const auto valid_cov = [](const Eigen::Matrix4d& cov) {


### PR DESCRIPTION
Thank you for making this great software open. I have always admired your work.

I have added an abnormal case handling code.
The offline viewer falls into such case when the glim fails to save last few submaps (It surely occurs at least on my environment sometimes... still investigating that part)