### PR TITLE
[feature] add MMS cropbox filter

### DIFF
--- a/config/config_preprocess.json
+++ b/config/config_preprocess.json
@@ -9,6 +9,7 @@
   // enable_outlier_removal      : If true, enable statistical outlier removal
   // outlier_removal_k           : Number of neighbors for outlier removal
   // outlier_std_mul_factor      : Standard deviation multiplier for outlier removal
+  // enable_cropbox_filter       : Filter points inside MMS bounding box
   // k_correspondences           : Number of neighbors for covariance estimation
   // num_threads                 : Number of threads for preprocessing
   */
@@ -22,6 +23,7 @@
     "enable_outlier_removal": false,
     "outlier_removal_k": 10,
     "outlier_std_mul_factor": 1.0,
+    "enable_cropbox_filter": false,
     "k_correspondences": 10,
     "num_threads": 2
   }

--- a/config/config_preprocess.json
+++ b/config/config_preprocess.json
@@ -9,7 +9,10 @@
   // enable_outlier_removal      : If true, enable statistical outlier removal
   // outlier_removal_k           : Number of neighbors for outlier removal
   // outlier_std_mul_factor      : Standard deviation multiplier for outlier removal
-  // enable_cropbox_filter       : Filter points inside MMS bounding box
+  // enable_cropbox_filter       : If true, filter points out points within box
+  // crop_bbox_frame             : Bounding box reference frame
+  // crop_bbox_min               : Bounding box min point
+  // crop_bbox_max               : Bounding box max point
   // k_correspondences           : Number of neighbors for covariance estimation
   // num_threads                 : Number of threads for preprocessing
   */
@@ -24,6 +27,9 @@
     "outlier_removal_k": 10,
     "outlier_std_mul_factor": 1.0,
     "enable_cropbox_filter": false,
+    "crop_bbox_frame": "lidar",
+    "crop_bbox_min": [-1.0, -1.0, -1.0],
+    "crop_bbox_max": [1.0, 1.0, 1.0],
     "k_correspondences": 10,
     "num_threads": 2
   }

--- a/config/config_sensors.json
+++ b/config/config_sensors.json
@@ -1,8 +1,5 @@
 {
   /*** Sensor configurations ***
-  // --- MMS config ---
-  // mms_bbox                    : Mapping device dimensions in IMU frame
-  //
   // --- IMU config ---
   // imu_acc_noise               : Accelerometer noise
   // imu_gyro_noise              : Gyroscope noise
@@ -44,15 +41,6 @@
   // rooftop: [0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0]
   */
   "sensors": {
-    // MMS config
-    "mms_bbox": [
-      -1.0, // min x
-      1.0,  // max x
-      -1.0, // min y
-      1.0,  // max y
-      -1.0, // min z
-      1.0   // max z
-    ],
     // IMU config
     "imu_acc_noise": 0.05,
     "imu_gyro_noise": 0.02,

--- a/config/config_sensors.json
+++ b/config/config_sensors.json
@@ -1,5 +1,8 @@
 {
   /*** Sensor configurations ***
+  // --- MMS config ---
+  // mms_bbox                    : Mapping device dimensions in IMU frame
+  //
   // --- IMU config ---
   // imu_acc_noise               : Accelerometer noise
   // imu_gyro_noise              : Gyroscope noise
@@ -41,6 +44,15 @@
   // rooftop: [0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0]
   */
   "sensors": {
+    // MMS config
+    "mms_bbox": [
+      -1.0, // min x
+      1.0,  // max x
+      -1.0, // min y
+      1.0,  // max y
+      -1.0, // min z
+      1.0   // max z
+    ],
     // IMU config
     "imu_acc_noise": 0.05,
     "imu_gyro_noise": 0.02,

--- a/include/glim/preprocess/cloud_preprocessor.hpp
+++ b/include/glim/preprocess/cloud_preprocessor.hpp
@@ -18,6 +18,11 @@ public:
   ~CloudPreprocessorParams();
 
 public:
+  struct BoundingBox {
+    Eigen::Vector3d min;
+    Eigen::Vector3d max;
+  };
+
   double distance_near_thresh;        ///< Minimum distance threshold
   double distance_far_thresh;         ///< Maximum distance threshold
   bool global_shutter;                ///< Assume all points in a scan are takes at the same moment and replace per-point timestamps with zero (disable deskewing)
@@ -28,7 +33,11 @@ public:
   bool enable_outlier_removal;        ///< If true, apply statistical outlier removal
   int outlier_removal_k;              ///< Number of neighbors used for outlier removal
   double outlier_std_mul_factor;      ///< Statistical outlier removal std dev threshold multiplication factor
+  bool enable_cropbox_filter;         ///< If true, filter points in MMS bounding box
   int k_correspondences;              ///< Number of neighboring points
+
+  Eigen::Isometry3d T_imu_lidar;      ///< LiDAR-IMU transformation
+  BoundingBox mms_bbox;               ///< MMS bounding box
 
   int num_threads;  ///< Number of threads
 };

--- a/include/glim/preprocess/cloud_preprocessor.hpp
+++ b/include/glim/preprocess/cloud_preprocessor.hpp
@@ -18,11 +18,6 @@ public:
   ~CloudPreprocessorParams();
 
 public:
-  struct BoundingBox {
-    Eigen::Vector3d min;
-    Eigen::Vector3d max;
-  };
-
   double distance_near_thresh;        ///< Minimum distance threshold
   double distance_far_thresh;         ///< Maximum distance threshold
   bool global_shutter;                ///< Assume all points in a scan are takes at the same moment and replace per-point timestamps with zero (disable deskewing)
@@ -33,13 +28,14 @@ public:
   bool enable_outlier_removal;        ///< If true, apply statistical outlier removal
   int outlier_removal_k;              ///< Number of neighbors used for outlier removal
   double outlier_std_mul_factor;      ///< Statistical outlier removal std dev threshold multiplication factor
-  bool enable_cropbox_filter;         ///< If true, filter points in MMS bounding box
+  bool enable_cropbox_filter;         ///< If true, filter points out points within box
+  std::string crop_bbox_frame;        ///< Bounding box reference frame
+  Eigen::Vector3d crop_bbox_min;      ///< Bounding box min point
+  Eigen::Vector3d crop_bbox_max;      ///< Bounding box max point
+  Eigen::Isometry3d T_imu_lidar;      ///< LiDAR-IMU transformation when cropbox is defined in IMU frame
   int k_correspondences;              ///< Number of neighboring points
 
-  Eigen::Isometry3d T_imu_lidar;      ///< LiDAR-IMU transformation
-  BoundingBox mms_bbox;               ///< MMS bounding box
-
-  int num_threads;  ///< Number of threads
+  int num_threads;                    ///< Number of threads
 };
 
 /**

--- a/src/glim/preprocess/cloud_preprocessor.cpp
+++ b/src/glim/preprocess/cloud_preprocessor.cpp
@@ -22,6 +22,15 @@ CloudPreprocessorParams::CloudPreprocessorParams() {
   Config sensor_config(GlobalConfig::get_config_path("config_sensors"));
 
   global_shutter = sensor_config.param<bool>("sensors", "global_shutter_lidar", false);
+  Eigen::Isometry3d T_lidar_imu = sensor_config.param<Eigen::Isometry3d>("sensors", "T_lidar_imu", Eigen::Isometry3d::Identity());
+  T_imu_lidar = T_lidar_imu.inverse();
+
+  std::vector<double> tmp_bbox = sensor_config.param<std::vector<double>>("sensors", "mms_bbox", {});
+  mms_bbox.min = {tmp_bbox[0], tmp_bbox[2], tmp_bbox[4]};
+  mms_bbox.max = {tmp_bbox[1], tmp_bbox[3], tmp_bbox[5]};
+  if ((mms_bbox.min.array() > mms_bbox.max.array()).any()) {
+    throw std::runtime_error(fmt::format("Invalid bbox configuration: min=({}, {}, {}), max=({}, {}, {})", mms_bbox.min.x(), mms_bbox.min.y(), mms_bbox.min.z(), mms_bbox.max.x(), mms_bbox.max.y(), mms_bbox.max.z()));
+  }
 
   distance_near_thresh = config.param<double>("preprocess", "distance_near_thresh", 1.0);
   distance_far_thresh = config.param<double>("preprocess", "distance_far_thresh", 100.0);
@@ -32,7 +41,7 @@ CloudPreprocessorParams::CloudPreprocessorParams() {
   enable_outlier_removal = config.param<bool>("preprocess", "enable_outlier_removal", false);
   outlier_removal_k = config.param<int>("preprocess", "outlier_removal_k", 10);
   outlier_std_mul_factor = config.param<double>("preprocess", "outlier_std_mul_factor", 2.0);
-
+  enable_cropbox_filter = config.param<bool>("preprocess", "enable_cropbox_filter", false);
   k_correspondences = config.param<int>("preprocess", "k_correspondences", 8);
 
   num_threads = config.param<int>("preprocess", "num_threads", 2);
@@ -113,6 +122,19 @@ PreprocessedFrame::Ptr CloudPreprocessor::preprocess_impl(const RawPoints::Const
 
   if (params.global_shutter) {
     std::fill(frame->times, frame->times + frame->size(), 0.0);
+  }
+
+  // MMS cropbox filter
+  if (params.enable_cropbox_filter) {
+    auto is_inside_mms_bbox = [&](const Eigen::Vector3d& p_lidar) {
+      const auto p_imu = params.T_imu_lidar * p_lidar;
+      return (p_imu.array() >= params.mms_bbox.min.array()).all()
+          && (p_imu.array() <= params.mms_bbox.max.array()).all();
+    };
+    // keep only points outside the MMS box
+    frame = gtsam_points::filter(frame, [&](const auto& pt) {
+      return !is_inside_mms_bbox(pt.template head<3>());
+    });
   }
 
   // Outlier removal


### PR DESCRIPTION
Implement a simple cropbox filter to remove LIDAR points hitting the MMS.

Feature is enabled by setting `preprocess/enable_cropbox_filter` to `true` in `config_preprocess.json`. Cropbox size is defined by `sensors/mms_bbox` vector in `config_sensors.json`. Coordinates are expressed in IMU frame.

Example with a vehicle:

Before:
![without_cropbox](https://github.com/user-attachments/assets/5ab7f086-2eea-4b23-864d-18fbe1a4e319)

After:
![with_cropbox](https://github.com/user-attachments/assets/03ad30ed-1a90-455b-9d6b-8a12c745271d)
