### PR TITLE
Add on_raw_points_received callback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ add_library(glim SHARED
   src/glim/util/data_validator.cpp
   src/glim/util/serialization.cpp
   # preprocess
+  src/glim/preprocess/callbacks.cpp
   src/glim/preprocess/cloud_preprocessor.cpp
   # common process
   src/glim/common/imu_integration.cpp

--- a/config/config_sensors.json
+++ b/config/config_sensors.json
@@ -9,6 +9,8 @@
   // --- LiDAR config ---
   // global_shutter_lidar        : If true, fill per-point timestamps with zero and disable points deskewing
   // T_lidar_imu                 : LiDAR-IMU transformation (See below for the format)
+  // intensity_field             : Field name used for extracting point intensity from PointCloud2 message
+  // ring_field                  : Field name used for extracting ring number (laser ID) from PointCloud2 message
   //
   // --- LiDAR per-point time settings ---
   // autoconf_perpoint_times     : If true, automatically configure per-point timestamps. If false, use the following settings.
@@ -57,6 +59,8 @@
       0.0,
       1.0
     ],
+    "intensity_field": "intensity",
+    "ring_field": "",
     // LiDAR per-point time settings
     "autoconf_perpoint_times": true,
     "autoconf_prefer_frame_time": false,

--- a/include/glim/preprocess/callbacks.hpp
+++ b/include/glim/preprocess/callbacks.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <glim/util/callback_slot.hpp>
+#include <glim/util/raw_points.hpp>
+
+namespace glim {
+
+/**
+ * @brief Point cloud preprocessing related callbacks
+ *
+ */
+struct PreprocessCallbacks {
+  /**
+   * @brief Raw points arrival callback
+   * @param points  Raw points received from the sensor
+   */
+  static CallbackSlot<void(const RawPoints::ConstPtr& points)> on_raw_points_received;
+};
+}

--- a/include/glim/util/raw_points.hpp
+++ b/include/glim/util/raw_points.hpp
@@ -23,6 +23,7 @@ public:
   std::vector<double> intensities;      ///< Point intensities
   std::vector<Eigen::Vector4d> points;  ///< Point coordinates
   std::vector<Eigen::Vector4d> colors;  ///< Point colors
+  std::vector<uint32_t> rings;          ///< Ring numbers of scanned points
 };
 
 }  // namespace glim

--- a/src/glim/preprocess/callbacks.cpp
+++ b/src/glim/preprocess/callbacks.cpp
@@ -1,0 +1,5 @@
+#include <glim/preprocess/callbacks.hpp>
+
+namespace glim {
+CallbackSlot<void(const RawPoints::ConstPtr& points)> PreprocessCallbacks::on_raw_points_received;
+}  // namespace glim

--- a/src/glim/preprocess/cloud_preprocessor.cpp
+++ b/src/glim/preprocess/cloud_preprocessor.cpp
@@ -1,4 +1,5 @@
 #include <glim/preprocess/cloud_preprocessor.hpp>
+#include <glim/preprocess/callbacks.hpp>
 
 #include <fstream>
 #include <iostream>
@@ -67,6 +68,7 @@ CloudPreprocessor::CloudPreprocessor(const CloudPreprocessorParams& params) : pa
 CloudPreprocessor::~CloudPreprocessor() {}
 
 PreprocessedFrame::Ptr CloudPreprocessor::preprocess(const RawPoints::ConstPtr& raw_points) {
+  PreprocessCallbacks::on_raw_points_received(raw_points);
   if (gtsam_points::is_omp_default() || params.num_threads == 1 || !tbb_task_arena) {
     return preprocess_impl(raw_points);
   }


### PR DESCRIPTION
This PR contains the following modifications:

### Extract ring number (laser ID) from `PointCloud2`
A new field `ring` is added to the `RawPoints` class, and `extract_raw_points` is modified to extract ring numbers of points from `PointCloud2` messages. Ring numbers might be useful for scenarios like object detection and ground segmentation. Adding support for ring numbers allow extension modules to perform specialized mapping tasks in parallel with SLAM, e.g. creating curb maps.

### New `on_raw_points_received` callback
Currently `glim_ros2` allows the user to store `RawPoints` along with `PreprocessedFrame` by enabling `keep_raw_points` option. However, `PreprocessedFrame` will later be attached to `EstimationFrame` which may live in the memory for an extended period. Due to the large size of `RawPoints` objects, this will consume large amount of memory.
`on_raw_points_received` callback is added to allow extension modules to deal with `RawPoints` without adding too much memory consumptions.

Note:
1. GLIM does not make use of ring numbers currently so I didn't add the field to `PreprocessedFrame`.
2. `glim_ros2` will also need to be updated accordingly to actually extract ring numbers. I'll submit a PR for this later.