### PR TITLE
Add BUILD_WITH_OPENCV build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ endif()
 if(BUILD_WITH_OPENCV)
   set(GLIM_USE_OPENCV 1)
   find_package(OpenCV REQUIRED COMPONENTS core)
+else()
+  set(GLIM_USE_OPENCV 0)
 endif()
 
 ###########

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ option(BUILD_WITH_CUDA "Build with GPU support" ON)
 option(BUILD_WITH_CUDA_MULTIARCH "Build with GPU cross-platform support" OFF)
 option(BUILD_WITH_VIEWER "Build with visualizer" ON)
 option(BUILD_WITH_MARCH_NATIVE "Build with -march=native" OFF)
+option(BUILD_WITH_OPENCV "Build with OpenCV to support camera images" ON)
 
 if(BUILD_WITH_MARCH_NATIVE)
   add_definitions(-march=native)
@@ -23,7 +24,6 @@ endif()
 
 find_package(Boost REQUIRED serialization)
 find_package(Eigen3 REQUIRED)
-find_package(OpenCV REQUIRED COMPONENTS core)
 find_package(GTSAM REQUIRED)
 find_package(gtsam_points REQUIRED)
 find_package(OpenMP REQUIRED)
@@ -31,6 +31,11 @@ find_package(spdlog REQUIRED)
 
 if(BUILD_WITH_VIEWER)
   find_package(Iridescence REQUIRED)
+endif()
+
+if(BUILD_WITH_OPENCV)
+  set(GLIM_USE_OPENCV 1)
+  find_package(OpenCV REQUIRED COMPONENTS core)
 endif()
 
 ###########
@@ -105,6 +110,9 @@ target_link_libraries(glim
   $<TARGET_NAME_IF_EXISTS:Iridescence::Iridescence>
   ${OpenCV_LIBRARIES}
 )
+if(BUILD_WITH_OPENCV)
+  target_compile_definitions(glim PUBLIC GLIM_USE_OPENCV)
+endif()
 list(APPEND glim_LIBRARIES glim)
 
 # Create shared libraries for estimation modules

--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ If you find this package useful for your project, please consider leaving a comm
 ### Mandatory
 - [Eigen](https://eigen.tuxfamily.org/index.php)
 - [nanoflann](https://github.com/jlblancoc/nanoflann)
-- [OpenCV](https://opencv.org/)
 - [GTSAM](https://github.com/borglab/gtsam)
 - [gtsam_points](https://github.com/koide3/gtsam_points)
 
 ### Optional
 - [CUDA](https://developer.nvidia.com/cuda-toolkit)
+- [OpenCV](https://opencv.org/)
 - [OpenMP](https://www.openmp.org/)
 - [ROS/ROS2](https://www.ros.org/)
 - [Iridescence](https://github.com/koide3/iridescence)

--- a/cmake/glim-config.cmake.in
+++ b/cmake/glim-config.cmake.in
@@ -11,11 +11,11 @@ include_guard()
 
 set(BUILD_WITH_CUDA @BUILD_WITH_CUDA@)
 set(BUILD_WITH_VIEWER @BUILD_WITH_VIEWER@)
+set(GLIM_USE_OPENCV @GLIM_USE_OPENCV@)
 
 include(CMakeFindDependencyMacro)
 find_dependency(Boost REQUIRED serialization)
 find_dependency(Eigen3 REQUIRED)
-find_dependency(OpenCV REQUIRED COMPONENTS core)
 find_dependency(gtsam_points REQUIRED)
 find_dependency(GTSAM REQUIRED)
 find_dependency(OpenMP REQUIRED)
@@ -27,6 +27,10 @@ endif()
 
 if(BUILD_WITH_VIEWER)
   find_dependency(Iridescence REQUIRED)
+endif()
+
+if(GLIM_USE_OPENCV)
+  find_dependency(OpenCV REQUIRED COMPONENTS core)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/glim-targets.cmake")

--- a/include/glim/mapping/async_global_mapping.hpp
+++ b/include/glim/mapping/async_global_mapping.hpp
@@ -31,12 +31,14 @@ public:
    */
   ~AsyncGlobalMapping();
 
+#ifdef GLIM_USE_OPENCV
   /**
    * @brief Insert an image
    * @param stamp   Timestamp
    * @param image   Image
    */
   void insert_image(const double stamp, const cv::Mat& image);
+#endif
 
   /**
    * @brief Insert an IMU frame
@@ -85,7 +87,9 @@ private:
   std::atomic_bool end_of_sequence;  ///< Flag to stop the thread when the input queues become empty (Soft kill switch)
   std::thread thread;
 
+#ifdef GLIM_USE_OPENCV
   ConcurrentVector<std::pair<double, cv::Mat>> input_image_queue;
+#endif
   ConcurrentVector<Eigen::Matrix<double, 7, 1>> input_imu_queue;
   ConcurrentVector<SubMap::Ptr> input_submap_queue;
 

--- a/include/glim/mapping/async_sub_mapping.hpp
+++ b/include/glim/mapping/async_sub_mapping.hpp
@@ -25,12 +25,14 @@ public:
    */
   ~AsyncSubMapping();
 
+#ifdef GLIM_USE_OPENCV
   /**
    * @brief Insert an image
    * @param stamp   Timestamp
    * @param image   Image
    */
   void insert_image(const double stamp, const cv::Mat& image);
+#endif
 
   /**
    * @brief Insert an IMU data
@@ -72,7 +74,9 @@ private:
   std::atomic_bool end_of_sequence;  // Flag to stop the thread when the input queues become empty (Soft kill switch)
   std::thread thread;
 
+#ifdef GLIM_USE_OPENCV
   ConcurrentVector<std::pair<double, cv::Mat>> input_image_queue;
+#endif
   ConcurrentVector<Eigen::Matrix<double, 7, 1>> input_imu_queue;
   ConcurrentVector<EstimationFrame::ConstPtr> input_frame_queue;
 

--- a/include/glim/mapping/callbacks.hpp
+++ b/include/glim/mapping/callbacks.hpp
@@ -4,9 +4,11 @@
 #include <glim/odometry/estimation_frame.hpp>
 #include <glim/mapping/sub_map.hpp>
 
+#ifdef GLIM_USE_OPENCV
 namespace cv {
 class Mat;
 }
+#endif
 
 namespace gtsam {
 class Values;
@@ -26,12 +28,14 @@ namespace glim {
  *
  */
 struct SubMappingCallbacks {
+#ifdef GLIM_USE_OPENCV
   /**
    * @brief Image input callback
    * @param stamp  Timestamp
    * @param image  Image
    */
   static CallbackSlot<void(const double stamp, const cv::Mat& image)> on_insert_image;
+#endif
 
   /**
    * @brief IMU input callback
@@ -80,12 +84,14 @@ struct SubMappingCallbacks {
  *
  */
 struct GlobalMappingCallbacks {
+#ifdef GLIM_USE_OPENCV
   /**
    * @brief Image input callback
    * @param stamp  Timestamp
    * @param image  Image
    */
   static CallbackSlot<void(const double stamp, const cv::Mat& image)> on_insert_image;
+#endif
 
   /**
    * @brief IMU input callback
@@ -145,4 +151,4 @@ struct GlobalMappingCallbacks {
    */
   static CallbackSlot<void(double)> request_to_find_overlapping_submaps;
 };
-}
+}  // namespace glim

--- a/include/glim/mapping/global_mapping_base.hpp
+++ b/include/glim/mapping/global_mapping_base.hpp
@@ -2,7 +2,9 @@
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
+#ifdef GLIM_USE_OPENCV
 #include <opencv2/core.hpp>
+#endif
 
 #include <glim/mapping/sub_map.hpp>
 
@@ -21,12 +23,14 @@ public:
   GlobalMappingBase();
   virtual ~GlobalMappingBase() {}
 
+#ifdef GLIM_USE_OPENCV
   /**
    * @brief Insert an image
    * @param stamp   Timestamp
    * @param image   Image
    */
   virtual void insert_image(const double stamp, const cv::Mat& image);
+#endif
 
   /**
    * @brief Insert an IMU frame

--- a/include/glim/mapping/sub_mapping_base.hpp
+++ b/include/glim/mapping/sub_mapping_base.hpp
@@ -2,7 +2,9 @@
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
+#ifdef GLIM_USE_OPENCV
 #include <opencv2/core.hpp>
+#endif
 
 #include <glim/odometry/estimation_frame.hpp>
 #include <glim/mapping/sub_map.hpp>
@@ -22,12 +24,14 @@ public:
   SubMappingBase();
   virtual ~SubMappingBase() {}
 
+#ifdef GLIM_USE_OPENCV
   /**
    * @brief Insert an image
    * @param stamp   Timestamp
    * @param image   Image
    */
   virtual void insert_image(const double stamp, const cv::Mat& image);
+#endif
 
   /**
    * @brief Insert an IMU data

--- a/include/glim/odometry/async_odometry_estimation.hpp
+++ b/include/glim/odometry/async_odometry_estimation.hpp
@@ -31,12 +31,14 @@ public:
    */
   ~AsyncOdometryEstimation();
 
+#ifdef GLIM_USE_OPENCV
   /**
    * @brief Insert an image into the odometry estimation
    * @param stamp   Timestamp
    * @param image   Image
    */
   void insert_image(const double stamp, const cv::Mat& image);
+#endif
 
   /**
    * @brief Insert an IMU data into the odometry estimation
@@ -77,8 +79,10 @@ private:
   std::atomic_bool end_of_sequence;  // Flag to stop the thread when the input queues become empty (Soft kill switch)
   std::thread thread;
 
-  // Input queues
+// Input queues
+#ifdef GLIM_USE_OPENCV
   ConcurrentVector<std::pair<double, cv::Mat>> input_image_queue;
+#endif
   ConcurrentVector<Eigen::Matrix<double, 7, 1>> input_imu_queue;
   ConcurrentVector<PreprocessedFrame::Ptr> input_frame_queue;
 

--- a/include/glim/odometry/callbacks.hpp
+++ b/include/glim/odometry/callbacks.hpp
@@ -4,9 +4,11 @@
 #include <glim/util/callback_slot.hpp>
 #include <glim/odometry/estimation_frame.hpp>
 
+#ifdef GLIM_USE_OPENCV
 namespace cv {
 class Mat;
 }
+#endif
 
 namespace gtsam {
 class Values;
@@ -44,12 +46,14 @@ public:
  *
  */
 struct OdometryEstimationCallbacks {
+#ifdef GLIM_USE_OPENCV
   /**
    * @brief Image input callback
    * @param stamp  Timestamp
    * @param image  Image
    */
   static CallbackSlot<void(const double stamp, const cv::Mat& image)> on_insert_image;
+#endif
 
   /**
    * @brief IMU input callback

--- a/include/glim/odometry/odometry_estimation_base.hpp
+++ b/include/glim/odometry/odometry_estimation_base.hpp
@@ -3,7 +3,9 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
+#ifdef GLIM_USE_OPENCV
 #include <opencv2/core.hpp>
+#endif
 #include <glim/odometry/estimation_frame.hpp>
 #include <glim/preprocess/preprocessed_frame.hpp>
 
@@ -27,12 +29,14 @@ public:
    */
   virtual bool requires_imu() const { return true; }
 
+#ifdef GLIM_USE_OPENCV
   /**
    * @brief Insert an image
    * @param stamp   Timestamp
    * @param image   Image
    */
   virtual void insert_image(const double stamp, const cv::Mat& image);
+#endif
 
   /**
    * @brief Insert an IMU data

--- a/src/glim/mapping/callbacks.cpp
+++ b/src/glim/mapping/callbacks.cpp
@@ -3,7 +3,9 @@
 namespace glim {
 
 // sub mapping
+#ifdef GLIM_USE_OPENCV
 CallbackSlot<void(const double, const cv::Mat&)> SubMappingCallbacks::on_insert_image;
+#endif
 CallbackSlot<void(const double, const Eigen::Vector3d&, const Eigen::Vector3d&)> SubMappingCallbacks::on_insert_imu;
 CallbackSlot<void(const EstimationFrame::ConstPtr& frame)> SubMappingCallbacks::on_insert_frame;
 CallbackSlot<void(int id, const EstimationFrame::ConstPtr&)> SubMappingCallbacks::on_new_keyframe;
@@ -13,7 +15,9 @@ CallbackSlot<void(const gtsam_points::LevenbergMarquardtOptimizationStatus&, con
 CallbackSlot<void(const SubMap::ConstPtr&)> SubMappingCallbacks::on_new_submap;
 
 // global mapping
+#ifdef GLIM_USE_OPENCV
 CallbackSlot<void(const double, const cv::Mat&)> GlobalMappingCallbacks::on_insert_image;
+#endif
 CallbackSlot<void(const double, const Eigen::Vector3d&, const Eigen::Vector3d&)> GlobalMappingCallbacks::on_insert_imu;
 CallbackSlot<void(const SubMap::ConstPtr& frame)> GlobalMappingCallbacks::on_insert_submap;
 

--- a/src/glim/mapping/global_mapping_base.cpp
+++ b/src/glim/mapping/global_mapping_base.cpp
@@ -10,9 +10,11 @@ using Callbacks = GlobalMappingCallbacks;
 
 GlobalMappingBase::GlobalMappingBase() : logger(create_module_logger("global")) {}
 
+#ifdef GLIM_USE_OPENCV
 void GlobalMappingBase::insert_image(const double stamp, const cv::Mat& image) {
   Callbacks::on_insert_image(stamp, image);
 }
+#endif
 
 void GlobalMappingBase::insert_imu(const double stamp, const Eigen::Vector3d& linear_acc, const Eigen::Vector3d& angular_vel) {
   Callbacks::on_insert_imu(stamp, linear_acc, angular_vel);

--- a/src/glim/mapping/sub_mapping_base.cpp
+++ b/src/glim/mapping/sub_mapping_base.cpp
@@ -10,9 +10,11 @@ using Callbacks = SubMappingCallbacks;
 
 SubMappingBase::SubMappingBase() : logger(create_module_logger("submap")) {}
 
+#ifdef GLIM_USE_OPENCV
 void SubMappingBase::insert_image(const double stamp, const cv::Mat& image) {
   Callbacks::on_insert_image(stamp, image);
 }
+#endif
 
 void SubMappingBase::insert_imu(const double stamp, const Eigen::Vector3d& linear_acc, const Eigen::Vector3d& angular_vel) {
   Callbacks::on_insert_imu(stamp, linear_acc, angular_vel);

--- a/src/glim/odometry/callbacks.cpp
+++ b/src/glim/odometry/callbacks.cpp
@@ -7,7 +7,9 @@ namespace glim {
 CallbackSlot<void(const PreprocessedFrame::ConstPtr& points, const Eigen::Isometry3d& T_odom_lidar)> IMUStateInitializationCallbacks::on_updated;
 CallbackSlot<void(const EstimationFrame::ConstPtr& estimated_frame)> IMUStateInitializationCallbacks::on_finished;
 
+#ifdef GLIM_USE_OPENCV
 CallbackSlot<void(const double, const cv::Mat&)> OdometryEstimationCallbacks::on_insert_image;
+#endif
 CallbackSlot<void(const double, const Eigen::Vector3d&, const Eigen::Vector3d&)> OdometryEstimationCallbacks::on_insert_imu;
 CallbackSlot<void(const PreprocessedFrame::Ptr& frame)> OdometryEstimationCallbacks::on_insert_frame;
 

--- a/src/glim/odometry/odometry_estimation_base.cpp
+++ b/src/glim/odometry/odometry_estimation_base.cpp
@@ -10,9 +10,11 @@ using Callbacks = OdometryEstimationCallbacks;
 
 OdometryEstimationBase::OdometryEstimationBase() : logger(create_module_logger("odom")) {}
 
+#ifdef GLIM_USE_OPENCV
 void OdometryEstimationBase::insert_image(const double stamp, const cv::Mat& image) {
   Callbacks::on_insert_image(stamp, image);
 }
+#endif
 
 void OdometryEstimationBase::insert_imu(const double stamp, const Eigen::Vector3d& linear_acc, const Eigen::Vector3d& angular_vel) {
   Callbacks::on_insert_imu(stamp, linear_acc, angular_vel);

--- a/src/glim/viewer/standard_viewer.cpp
+++ b/src/glim/viewer/standard_viewer.cpp
@@ -24,7 +24,9 @@
 
 #include <glk/colormap.hpp>
 #include <glk/texture.hpp>
+#ifdef GLIM_USE_OPENCV
 #include <glk/texture_opencv.hpp>
+#endif
 #include <glk/thin_lines.hpp>
 #include <glk/pointcloud_buffer.hpp>
 #include <glk/indexed_pointcloud_buffer.hpp>
@@ -137,6 +139,7 @@ void StandardViewer::set_callbacks() {
     });
   });
 
+#ifdef GLIM_USE_OPENCV
   // New image callback
   OdometryEstimationCallbacks::on_insert_image.add([this](const double stamp, const cv::Mat& image) {
     invoke([this, image] {
@@ -145,6 +148,7 @@ void StandardViewer::set_callbacks() {
       viewer->update_image("image", texture);
     });
   });
+#endif
 
   // New frame callback
   OdometryEstimationCallbacks::on_new_frame.add([this](const EstimationFrame::ConstPtr& new_frame) {


### PR DESCRIPTION
This PR adds a new `BUILD_WITH_OPENCV` build option which allows users to build glim without OpenCV when camera image support is not needed.

Users can check whether glim is built with OpenCV by:
1. In CMake projects: inspecting  the value of `GLIM_USE_OPENCV` variable
2. In source code: checking whether `GLIM_USE_OPENCV` compiler definition is defined

The default value of `BUILD_WITH_OPENCV` is set to `ON` to avoid breaking CI builds and existing projects.