### PR TITLE
Allow invoking callbacks with r-value refs

### DIFF
--- a/include/glim/util/callback_slot.hpp
+++ b/include/glim/util/callback_slot.hpp
@@ -43,7 +43,7 @@ public:
    * @param args  Arguments for the callbacks
    */
   template <class... Args>
-  void call(Args&... args) const {
+  void call(Args&&... args) const {
     if (callbacks.empty()) {
       return;
     }
@@ -60,7 +60,7 @@ public:
    * @param args  Arguments for the callbacks
    */
   template <class... Args>
-  void operator()(Args&... args) const {
+  void operator()(Args&&... args) const {
     return call(args...);
   }
 


### PR DESCRIPTION
This PR adds a new `ViewerCallbacks::request_to_invoke` callback, which allows extension modules to manipulate the window create by interactive/standard viewer on the viewer thread.

Currently performing visualization in extension modules is not supported as only a single `guik::LightViewer` is allowed in a process. `ViewerCallbacks::request_to_invoke` allows multiple extension modules to perform visualization in the main viewer window.