### PR TITLE
Offloading points and voxelmaps on GPU

### DIFF
--- a/config/config_global_mapping_gpu.json
+++ b/config/config_global_mapping_gpu.json
@@ -22,6 +22,13 @@
   // use_isam2_dogleg               : If true, use dogleg optimizer (robust but slow)
   // isam2_relinearize_skip         : Relinearization is performed every $isam2_relinearize_skip optimization calls
   // isam2_relinearize_thresh       : Relinearization is performed only when linear delta gets larger than this
+  //
+  // --- Memory settings ---
+  // gpu_memory_offload_mb          : Threshold for GPU memory offloading in MB (0 = disable offloading).
+  //                                : If GPU memory usage exceeds this value, old submap points and voxelmaps are offloaded to CPU memory.
+  //                                : Note that the current implementation doesn't support offloading of factors and graphics data, and thus
+  //                                : the actual GPU memory usage will be much larger than this value.
+  //                                : (Setting this to a half or quarter of the total GPU memory would be a good choice).
   */
   "global_mapping": {
     "so_name": "libglobal_mapping.so",
@@ -46,6 +53,8 @@
     // Optimizer settings
     "use_isam2_dogleg": false,
     "isam2_relinearize_skip": 1,
-    "isam2_relinearize_thresh": 0.1
+    "isam2_relinearize_thresh": 0.1,
+    // Memory settings
+    "gpu_memory_offload_mb": 2048
   }
 }

--- a/include/glim/mapping/global_mapping.hpp
+++ b/include/glim/mapping/global_mapping.hpp
@@ -99,11 +99,11 @@ private:
   std::mt19937 mt;
   int session_id;
 
-  std::uint64_t point_bytes_gpu;
+  size_t submap_bytes_gpu;
 
   std::unique_ptr<IMUIntegration> imu_integration;
   std::any stream_buffer_roundrobin;
-  
+
   std::vector<SubMap::Ptr> submaps;
   std::vector<gtsam_points::PointCloud::ConstPtr> subsampled_submaps;
 

--- a/include/glim/mapping/global_mapping.hpp
+++ b/include/glim/mapping/global_mapping.hpp
@@ -102,6 +102,7 @@ private:
   size_t submap_bytes_gpu;
 
   std::unique_ptr<IMUIntegration> imu_integration;
+  std::any main_stream;
   std::any stream_buffer_roundrobin;
 
   std::vector<SubMap::Ptr> submaps;

--- a/include/glim/mapping/global_mapping.hpp
+++ b/include/glim/mapping/global_mapping.hpp
@@ -35,6 +35,8 @@ public:
   bool enable_between_factors;
   std::string between_registration_type;
 
+  size_t gpu_memory_offload_mb;  // in MB
+
   std::string registration_error_factor_type;
   double submap_voxel_resolution;
   double submap_voxel_resolution_max;
@@ -84,6 +86,7 @@ private:
   std::shared_ptr<gtsam::NonlinearFactorGraph> create_matching_cost_factors(int current) const;
 
   void update_submaps();
+  void offload_gpu_memory();
   gtsam_points::ISAM2ResultExt update_isam2(const gtsam::NonlinearFactorGraph& new_factors, const gtsam::Values& new_values);
 
   void recover_graph() override;
@@ -96,9 +99,11 @@ private:
   std::mt19937 mt;
   int session_id;
 
+  std::uint64_t point_bytes_gpu;
+
   std::unique_ptr<IMUIntegration> imu_integration;
   std::any stream_buffer_roundrobin;
-
+  
   std::vector<SubMap::Ptr> submaps;
   std::vector<gtsam_points::PointCloud::ConstPtr> subsampled_submaps;
 

--- a/include/glim/viewer/standard_viewer.hpp
+++ b/include/glim/viewer/standard_viewer.hpp
@@ -27,7 +27,7 @@ namespace glim {
 class TrajectoryManager;
 struct EstimationFrame;
 
-struct SubMapMemoryStats;
+struct SubMap;
 struct FactorMemoryStats;
 
 class StandardViewer : public ExtensionModule {
@@ -89,8 +89,7 @@ private:
   float min_overlap;
 
   bool show_memory_stats;
-  int submap_memstats_count;
-  std::vector<SubMapMemoryStats> submap_memstats;
+  std::vector<std::shared_ptr<const SubMap>> submaps;
 
   int global_factor_stats_count;
   std::vector<FactorMemoryStats> global_factor_memstats;

--- a/include/glim/viewer/standard_viewer_mem.hpp
+++ b/include/glim/viewer/standard_viewer_mem.hpp
@@ -19,9 +19,12 @@ public:
   size_t voxelmap_cpu_bytes;  ///< CPU memory usage for voxel map
   size_t frame_gpu_bytes;     ///< GPU memory usage
   size_t voxelmap_gpu_bytes;  ///< GPU memory usage for voxel map
+  size_t frame_gpu_net_bytes;     ///< GPU memory usage for the frame
+  size_t voxelmap_gpu_net_bytes;  ///< GPU memory usage for the voxel map
 
-  size_t odom_cpu_bytes;  ///< Total CPU memory usage for all frames
-  size_t odom_gpu_bytes;  ///< Total GPU memory usage for all frames
+  size_t odom_cpu_bytes;      ///< Total CPU memory usage for all frames
+  size_t odom_gpu_bytes;      ///< Total GPU memory usage for all frames
+  size_t odom_gpu_net_bytes;  ///< Total GPU memory usage for all frames (networked)
 
   size_t num_custom_data;  ///< Number of custom data entries in the submap
 };

--- a/src/glim/odometry/callbacks.cpp
+++ b/src/glim/odometry/callbacks.cpp
@@ -1,6 +1,6 @@
 #include <glim/odometry/callbacks.hpp>
 
-#include <gtsam_unstable/nonlinear/FixedLagSmoother.h>
+#include <gtsam/nonlinear/FixedLagSmoother.h>
 
 namespace glim {
 

--- a/src/glim/viewer/standard_viewer.cpp
+++ b/src/glim/viewer/standard_viewer.cpp
@@ -72,7 +72,6 @@ StandardViewer::StandardViewer() : logger(create_module_logger("viewer")) {
   min_overlap = 0.2f;
 
   show_memory_stats = false;
-  submap_memstats_count = 0;
   global_factor_stats_count = 0;
   total_gl_bytes = 0;
 
@@ -529,6 +528,7 @@ void StandardViewer::set_callbacks() {
     const std::shared_ptr<Eigen::Isometry3d> T_world_origin(new Eigen::Isometry3d(submap->T_world_origin));
 
     invoke([this, submap, T_world_origin] {
+      submaps.emplace_back(submap);
       const double stamp_endpoint_R = submap->odom_frames.back()->stamp;
       const Eigen::Isometry3d T_world_endpoint_R = (*T_world_origin) * submap->T_origin_endpoint_R;
       trajectory->update_anchor(stamp_endpoint_R, T_world_endpoint_R);
@@ -559,19 +559,8 @@ void StandardViewer::set_callbacks() {
       submap_poses[i] = submaps[i]->T_world_origin.cast<float>();
     }
 
-    std::vector<SubMapMemoryStats> mem_stats;
-    if (show_memory_stats) {
-      mem_stats.reserve(submaps.size() - submap_memstats_count);
-      for (int i = submap_memstats_count; i < submaps.size(); i++) {
-        mem_stats.emplace_back(*submaps[i]);
-      }
-      submap_memstats_count = submaps.size();
-    }
-
-    invoke([this, latest_submap, submap_ids, submap_poses, mem_stats] {
+    invoke([this, latest_submap, submap_ids, submap_poses] {
       auto viewer = guik::LightViewer::instance();
-
-      submap_memstats.insert(submap_memstats.end(), mem_stats.begin(), mem_stats.end());
 
       std::vector<Eigen::Vector3f> submap_positions(submap_ids.size());
       last_submap_z = submap_poses.back().translation().z();
@@ -910,18 +899,26 @@ void StandardViewer::drawable_selection() {
 
     size_t points_cpu = 0;
     size_t points_gpu = 0;
+    size_t points_gpu_net = 0;
     size_t voxelmap_cpu = 0;
     size_t voxelmap_gpu = 0;
+    size_t voxelmap_gpu_net = 0;
     size_t odom_cpu = 0;
     size_t odom_gpu = 0;
+    size_t odom_gpu_net = 0;
 
-    for (const auto& m : submap_memstats) {
+    for (const auto& s : submaps) {
+      const SubMapMemoryStats m(*s);
+
       points_cpu += m.frame_cpu_bytes;
       points_gpu += m.frame_gpu_bytes;
+      points_gpu_net += m.frame_gpu_net_bytes;
       voxelmap_cpu += m.voxelmap_cpu_bytes;
       voxelmap_gpu += m.voxelmap_gpu_bytes;
+      voxelmap_gpu_net += m.voxelmap_gpu_net_bytes;
       odom_cpu += m.odom_cpu_bytes;
       odom_gpu += m.odom_gpu_bytes;
+      odom_gpu_net += m.odom_gpu_net_bytes;
     }
 
     size_t factors_cpu = 0;
@@ -935,14 +932,17 @@ void StandardViewer::drawable_selection() {
     constexpr double mb = 1.0 / (1024.0 * 1024.0);
     const size_t total_cpu = points_cpu + voxelmap_cpu + odom_cpu + factors_cpu;
     const size_t total_gpu = points_gpu + voxelmap_gpu + odom_gpu + factors_gpu + total_gl_bytes;
+    const size_t total_gpu_net = points_gpu_net + voxelmap_gpu_net + odom_gpu_net + factors_gpu + total_gl_bytes;
     const double total_cpu_mb = total_cpu * mb;
     const double total_gpu_mb = total_gpu * mb;
+    const double total_gpu_net_mb = total_gpu_net * mb;
 
     ImGui::Text("Global mapping memory usage");
-    if (ImGui::BeginTable("Global mapping memory usage", 3, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg)) {
-      const auto show_item = [=](const char* name, size_t cpu, size_t gpu) {
+    if (ImGui::BeginTable("Global mapping memory usage", 4, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg)) {
+      const auto show_item = [=](const char* name, size_t cpu, size_t gpu, size_t gpu_net = 0) {
         const double cpu_mb = cpu * mb;
         const double gpu_mb = gpu * mb;
+        const double gpu_net_mb = gpu_net * mb;
 
         ImGui::TableNextRow();
         ImGui::TableNextColumn();
@@ -951,19 +951,22 @@ void StandardViewer::drawable_selection() {
         ImGui::Text("%.2f MB / %.1f %%", cpu_mb, cpu_mb / total_cpu_mb * 100.0);
         ImGui::TableNextColumn();
         ImGui::Text("%.2f MB / %.1f %%", gpu * mb, gpu_mb / total_gpu_mb * 100.0);
+        ImGui::TableNextColumn();
+        ImGui::Text("%.2f MB / %.1f %%", gpu_net * mb, gpu_net_mb / total_gpu_mb * 100.0);
       };
 
       ImGui::TableSetupColumn("Item");
       ImGui::TableSetupColumn("CPU");
       ImGui::TableSetupColumn("GPU");
+      ImGui::TableSetupColumn("GPU (net)");
       ImGui::TableHeadersRow();
 
-      show_item("Total", total_cpu, total_gpu);
-      show_item("Points", points_cpu, points_gpu);
-      show_item("Voxelmap", voxelmap_cpu, voxelmap_gpu);
-      show_item("Odom frames", odom_cpu, odom_gpu);
-      show_item("Factors", factors_cpu, factors_gpu);
-      show_item("OpenGL", 0, total_gl_bytes);
+      show_item("Total", total_cpu, total_gpu, total_gpu_net);
+      show_item("Points", points_cpu, points_gpu, points_gpu_net);
+      show_item("Voxelmap", voxelmap_cpu, voxelmap_gpu, voxelmap_gpu_net);
+      show_item("Odom frames", odom_cpu, odom_gpu, odom_gpu_net);
+      show_item("Factors", factors_cpu, factors_gpu, factors_gpu);
+      show_item("OpenGL", 0, total_gl_bytes, total_gl_bytes);
 
       ImGui::EndTable();
     }


### PR DESCRIPTION
This PR enables offloading point and voxelmap data of old submaps from GPU memory.
It effectively reduces GPU memory consumption with a slight degradation of global optimization speed up to CPU-GPU data IO.