### PR TITLE
LiDAR intensity data support in GLIM

### DIFF
--- a/include/glim/mapping/async_global_mapping.hpp
+++ b/include/glim/mapping/async_global_mapping.hpp
@@ -72,7 +72,7 @@ public:
    */
   void save(const std::string& path);
 
-  std::vector<Eigen::Vector4d> export_points();
+  glk::PLYData export_points();
 
   std::shared_ptr<glim::GlobalMappingBase> get_global_mapping() {
     std::lock_guard<std::mutex> lock(global_mapping_mutex);

--- a/include/glim/mapping/global_mapping.hpp
+++ b/include/glim/mapping/global_mapping.hpp
@@ -69,7 +69,7 @@ public:
   virtual void optimize() override;
 
   virtual void save(const std::string& path) override;
-  virtual std::vector<Eigen::Vector4d> export_points() override;
+  virtual glk::PLYData export_points() override;
 
   /**
    * @brief Load a mapping result from a dumped directory

--- a/include/glim/mapping/global_mapping_base.hpp
+++ b/include/glim/mapping/global_mapping_base.hpp
@@ -7,6 +7,7 @@
 #endif
 
 #include <glim/mapping/sub_map.hpp>
+#include <glk/io/ply_io.hpp>
 
 namespace spdlog {
 class logger;
@@ -70,7 +71,7 @@ public:
   /**
    * @brief Export all the submap points
    */
-  virtual std::vector<Eigen::Vector4d> export_points() { return std::vector<Eigen::Vector4d>(); }
+  virtual glk::PLYData export_points() { return glk::PLYData(); }
 
   /**
    * @brief Load a global mapping module from a shared library

--- a/include/glim/mapping/global_mapping_pose_graph.hpp
+++ b/include/glim/mapping/global_mapping_pose_graph.hpp
@@ -97,7 +97,7 @@ public:
   virtual void optimize() override;
 
   virtual void save(const std::string& path) override;
-  virtual std::vector<Eigen::Vector4d> export_points() override;
+  virtual glk::PLYData export_points() override;
 
 private:
   void insert_submap(int current, const SubMap::Ptr& submap);

--- a/src/glim/mapping/async_global_mapping.cpp
+++ b/src/glim/mapping/async_global_mapping.cpp
@@ -67,7 +67,7 @@ void AsyncGlobalMapping::save(const std::string& path) {
   logger->info("saved");
 }
 
-std::vector<Eigen::Vector4d> AsyncGlobalMapping::export_points() {
+glk::PLYData AsyncGlobalMapping::export_points() {
   std::lock_guard<std::mutex> lock(global_mapping_mutex);
   logger->info("exporting points");
   auto points = global_mapping->export_points();

--- a/src/glim/mapping/global_mapping.cpp
+++ b/src/glim/mapping/global_mapping.cpp
@@ -634,22 +634,20 @@ void GlobalMapping::save(const std::string& path) {
   GlobalConfig::instance()->dump(path + "/config");
 }
 
-std::vector<Eigen::Vector4d> GlobalMapping::export_points() {
-  int num_all_points = 0;
+
+glk::PLYData GlobalMapping::export_points() {
+  glk::PLYData ply_data;
   for (const auto& submap : submaps) {
-    num_all_points += submap->frame->size();
+    for (int i = 0; i < submap->frame->size(); i++) {
+      Eigen::Vector3f point = (submap->T_world_origin * submap->frame->points[i]).head<3>().cast<float>();
+      ply_data.vertices.push_back(point);
+
+      if (submap->frame->has_intensities()) { 
+        ply_data.intensities.push_back(submap->frame->intensities[i]);
+      }
+    }
   }
-
-  std::vector<Eigen::Vector4d> all_points;
-  all_points.reserve(num_all_points);
-
-  for (const auto& submap : submaps) {
-    std::transform(submap->frame->points, submap->frame->points + submap->frame->size(), std::back_inserter(all_points), [&](const Eigen::Vector4d& p) {
-      return submap->T_world_origin * p;
-    });
-  }
-
-  return all_points;
+  return ply_data;
 }
 
 bool GlobalMapping::load(const std::string& path) {

--- a/src/glim/mapping/global_mapping_pose_graph.cpp
+++ b/src/glim/mapping/global_mapping_pose_graph.cpp
@@ -243,7 +243,7 @@ void GlobalMappingPoseGraph::save(const std::string& path) {
   }
 }
 
-std::vector<Eigen::Vector4d> GlobalMappingPoseGraph::export_points() {
+glk::PLYData GlobalMappingPoseGraph::export_points() {
   return {};
 }
 

--- a/src/glim/mapping/sub_mapping.cpp
+++ b/src/glim/mapping/sub_mapping.cpp
@@ -337,7 +337,6 @@ void SubMapping::insert_frame(const EstimationFrame::ConstPtr& odom_frame_) {
 
 void SubMapping::insert_keyframe(const int current, const EstimationFrame::ConstPtr& odom_frame) {
   gtsam_points::PointCloud::ConstPtr deskewed_frame = odom_frame->frame;
-
   // Re-perform deskewing with smoothed IMU poses
   if (params.enable_imu && odom_frame->raw_frame && odom_frame->imu_rate_trajectory.cols() >= 2) {
     if (std::abs(odom_frame->stamp - odom_frame->imu_rate_trajectory(0, 0)) > 1e-3) {
@@ -369,7 +368,7 @@ void SubMapping::insert_keyframe(const int current, const EstimationFrame::Const
       frame->points[i] = odom_frame->T_lidar_imu.inverse() * frame->points[i];
     }
     frame->add_covs(covariance_estimation->estimate(frame->points_storage, odom_frame->raw_frame->neighbors));
-
+    frame->add_intensities(odom_frame->raw_frame->intensities);
     deskewed_frame = frame;
   }
 

--- a/src/glim/viewer/offline_viewer.cpp
+++ b/src/glim/viewer/offline_viewer.cpp
@@ -215,12 +215,11 @@ bool OfflineViewer::export_map(guik::ProgressInterface& progress, const std::str
   progress.set_text("Concatenating submaps");
   progress.set_maximum(3);
   progress.increment();
-  const auto points = async_global_mapping->export_points();
+  const glk::PLYData points = async_global_mapping->export_points();
 
   progress.set_text("Writing to file");
   progress.increment();
-  glk::save_ply_binary(path, points.data(), points.size());
-
+  glk::save_ply_binary(path, points);
   return true;
 }
 


### PR DESCRIPTION
This PR adds support for using **LiDAR intensity values** within the GLIM SLAM pipeline. This update allows intensity information to be preserved and exported.

**Key Updates**
- Intensities values are now incorporated in the `insert_frame()` in `sub_mapping.cpp`.
- The data structure returned by `export_points()` has been updated from `std::vector<Eigen::Vector4d>` to `glk::PLYData.`

This contribution was developed as part of ongoing research at the [Kantor Lab](https://www.ri.cmu.edu/robotics-groups/kantorlab/), Carnegie Mellon University.