### PR TITLE
Fix compile error for vector<bool> format by including fmt/std.h

### DIFF
--- a/include/glim/util/convert_to_string.hpp
+++ b/include/glim/util/convert_to_string.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 #include <fmt/format.h>
+#include <fmt/std.h>
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 


### PR DESCRIPTION
The codebase is trying to format bool vectors, which used to fail with fmt (https://github.com/fmtlib/fmt/issues/3567) but is supported nowadays, but it requires including this header. Otherwise we get something like this

```
/opt/homebrew/include/fmt/base.h:2310:45: error: implicit instantiation of undefined template 'fmt::detail::type_is_unformattable_for<std::__bit_const_reference<std::vector<bool>>, char>'
 2310 |     type_is_unformattable_for<T, char_type> _;
      |                                             ^
/opt/homebrew/include/fmt/base.h:2283:44: note: in instantiation of function template specialization 'fmt::detail::value<fmt::context>::value<std::__bit_const_reference<std::vector<bool>>, 0>' requested here
 2283 |   FMT_CONSTEXPR20 FMT_INLINE value(T& x) : value(x, custom_tag()) {}
      |                                            ^
/opt/homebrew/include/fmt/format.h:4349:40: note: in instantiation of function template specialization 'fmt::detail::value<fmt::context>::value<const std::__bit_const_reference<std::vector<bool>>, 0>' requested here
 4349 |   return vformat(fmt.str, vargs<T...>{{args...}});
      |                                        ^
/Users/rasmus/Downloads/source_builds/glim/include/glim/util/convert_to_string.hpp:15:15: note: in instantiation of function template specialization 'fmt::format<const std::__bit_const_reference<std::vector<bool>> &>' requested here
   15 |   return fmt::format("{}", value);
      |               ^
/Users/rasmus/Downloads/source_builds/glim/include/glim/util/convert_to_string.hpp:26:12: note: in instantiation of function template specialization 'glim::convert_to_string<std::__bit_const_reference<std::vector<bool>>>' requested here
   26 |     sst << convert_to_string(values[i]);
      |            ^
/Users/rasmus/Downloads/source_builds/glim/include/glim/util/config_impl.hpp:152:42: note: in instantiation of function template specialization 'glim::convert_to_string<bool>' requested here
  152 |     spdlog::warn("use default_value={}", convert_to_string(default_value));
      |                                          ^
/opt/homebrew/include/fmt/base.h:2150:45: note: template is declared here
 2150 | template <typename T, typename Char> struct type_is_unformattable_for;
…
```

at least on macos with current homebrew fmt and spdlog.