### PR TITLE
feature: expose IMU gravity param and set via gtsam::PreintegrationParams

### DIFF
--- a/config/config_sensors.json
+++ b/config/config_sensors.json
@@ -1,6 +1,7 @@
 {
   /*** Sensor configurations ***
   // --- IMU config ---
+  // imu_gravity_magnitude       : Gravity magnitude used for IMU preintegration
   // imu_acc_noise               : Accelerometer noise
   // imu_gyro_noise              : Gyroscope noise
   // imu_int_noise               : Integration noise
@@ -44,6 +45,7 @@
   */
   "sensors": {
     // IMU config
+    "imu_gravity_magnitude": 9.80665,
     "imu_acc_noise": 0.05,
     "imu_gyro_noise": 0.02,
     "imu_int_noise": 0.001,

--- a/include/glim/common/imu_integration.hpp
+++ b/include/glim/common/imu_integration.hpp
@@ -15,6 +15,7 @@ struct IMUIntegrationParams {
   ~IMUIntegrationParams();
 
   bool upright;       // If true, +Z = up
+  double gravity_magnitude;  // Gravity magnitude used by GTSAM IMU preintegration
   double acc_noise;   // Linear acceleration noise
   double gyro_noise;  // Angular velocity noise
   double int_noise;   // Integration noise

--- a/src/glim/common/imu_integration.cpp
+++ b/src/glim/common/imu_integration.cpp
@@ -8,6 +8,7 @@ IMUIntegrationParams::IMUIntegrationParams(const bool upright) {
   glim::Config config_sensors(glim::GlobalConfig::get_config_path("config_sensors"));
 
   this->upright = upright;
+  this->gravity_magnitude = config_sensors.param<double>("sensors", "imu_gravity_magnitude", 9.80665);
   this->acc_noise = config_sensors.param<double>("sensors", "imu_acc_noise", 0.01);
   this->gyro_noise = config_sensors.param<double>("sensors", "imu_gyro_noise", 0.001);
   this->int_noise = config_sensors.param<double>("sensors", "imu_int_noise", 0.001);
@@ -16,9 +17,9 @@ IMUIntegrationParams::IMUIntegrationParams(const bool upright) {
 IMUIntegrationParams::~IMUIntegrationParams() {}
 
 IMUIntegration::IMUIntegration(const IMUIntegrationParams& params) {
-  auto imu_params = gtsam::PreintegrationParams::MakeSharedU();
+  auto imu_params = gtsam::PreintegrationParams::MakeSharedU(params.gravity_magnitude);
   if (!params.upright) {
-    imu_params = gtsam::PreintegrationParams::MakeSharedD();
+    imu_params = gtsam::PreintegrationParams::MakeSharedD(params.gravity_magnitude);
   }
 
   imu_params->accelerometerCovariance = gtsam::Matrix3::Identity() * std::pow(params.acc_noise, 2);


### PR DESCRIPTION
It is sometimes useful to set a different gravity magnitue for the IMU, but current implementation uses gtsam default as defined [here](https://gtsam.org/doxygen/4.0.0/a03531.html).

This PR exposes a gravity magnitude parameter and allows it to be optionally set in `config_sensors.yaml`.