### PR TITLE
Fix some English typos in comments, docs, and UI strings

### DIFF
--- a/docs/demo.md
+++ b/docs/demo.md
@@ -68,4 +68,4 @@ ros2 run glim_ros glim_rosbag --ros-args -p config_path:=$(realpath config/kinec
     - Only odometry estimation was performed, no global optimization.
     - Visualization was run on another PC that received points and pose messages via ethernet.  
       (rviz took about a half of Jetson Nano's computation capability without rendering anything!!)
-    - (2024/07/04) The current version of GLIM does not support CUDA 11 and older. Some minor midifications are expected to be necessary.
+    - (2024/07/04) The current version of GLIM does not support CUDA 11 and older. Some minor modifications are expected to be necessary.

--- a/docs/extend.md
+++ b/docs/extend.md
@@ -7,7 +7,7 @@ In this package, the (SE3) transformation from frame B to frame A is denoted as 
 
 For instance, the transformation from a LiDAR frame to the world frame (i.e., a LiDAR pose in the world frame) is represented as ```T_world_lidar```, and a point in the LiDAR frame ```p_lidar``` is transformed into the world frame by ```p_world = T_world_lidar * p_lidar```.
 
-Similarty, ```v_A_B``` represents the velocity of frame B in frame A, and thus ```v_world_imu``` represents an IMU velocity in the world frame.
+Similarly, ```v_A_B``` represents the velocity of frame B in frame A, and thus ```v_world_imu``` represents an IMU velocity in the world frame.
 
 ## Variables
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@
 
 **GLIM** is a versatile and extensible range-based 3D mapping framework.
 
-- ***Accuracy:*** GLIM is based on direct multi-scan registration error minimization on factor graphs that enables to accurately retain the consistency of mappint results. GPU acceleration is supported to maximize the mapping speed and quality.
+- ***Accuracy:*** GLIM is based on direct multi-scan registration error minimization on factor graphs that enables to accurately retain the consistency of mapping results. GPU acceleration is supported to maximize the mapping speed and quality.
 - ***Easy-to-use:*** GLIM offers an interactive map correction interface that enables the user to manually correct mapping failures and easily refine mapping results.
 - ***Versatility:*** As we eliminated sensor-specific processes, GLIM can be applied to any kind of range sensors including:
     - Spinning-type LiDAR (e.g., Velodyne HDL32e and Ouster OS1)

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -1,7 +1,7 @@
 # Important parameters
 
 !!! info
-    See the [sensor setup buide](https://github.com/koide3/glim/wiki/Sensor-setup-guide) for configurations of popular sensors (including Livox MID360 and Azure Kinect).
+    See the [sensor setup guide](https://github.com/koide3/glim/wiki/Sensor-setup-guide) for configurations of popular sensors (including Livox MID360 and Azure Kinect).
 
 !!! info
     See the Configuration files section in [Getting started](quickstart.md) to change the location of configuration files.
@@ -41,7 +41,7 @@
         - **ivox_resolution** (default 0.5 m) : Resolution of iVox voxels used for GICP scan matching. This parameter also controls the maximum corresponding distance and should be set to a large value in outdoor environments (e.g., 1.0 m).
 
     - *"VGICP"* uses voxelized GICP scan matching that is faster but requires tuning **vgicp_resolution** parameter for good estimation in indoor environments.
-        - **vgicp_resolution** (default 0.5 m) : Resolution of VIGP voxels used for VGICP scan matching. Use a small value for indoor environments (e.g., 0.25 ~ 0.5 m) and a large value for outdoor environments (0.5 ~ 2.0 m).
+        - **vgicp_resolution** (default 0.5 m) : Resolution of VGICP voxels used for VGICP scan matching. Use a small value for indoor environments (e.g., 0.25 ~ 0.5 m) and a large value for outdoor environments (0.5 ~ 2.0 m).
 
 ## LiDAR-only Odometry Estimation (config_odometry_ct.json)
 

--- a/include/glim/common/cloud_deskewing.hpp
+++ b/include/glim/common/cloud_deskewing.hpp
@@ -6,7 +6,7 @@
 namespace glim {
 
 /**
- * @brief Dewsking point cloud
+ * @brief Deskewing point cloud
  */
 class CloudDeskewing {
 public:

--- a/include/glim/odometry/odometry_estimation_cpu.hpp
+++ b/include/glim/odometry/odometry_estimation_cpu.hpp
@@ -34,7 +34,7 @@ public:
   double ivox_min_dist;    ///< Minimum distance between points in an iVox cell (for GICP)
 
   double vgicp_resolution;               ///< Voxelmap resolution (for VGICP)
-  int vgicp_voxelmap_levels;             ///< Multi-resolution voxelmap levesl (for VGICP)
+  int vgicp_voxelmap_levels;             ///< Multi-resolution voxelmap levels (for VGICP)
   double vgicp_voxelmap_scaling_factor;  ///< Multi-resolution voxelmap scaling factor (for VGICP)
 };
 

--- a/include/glim/preprocess/cloud_preprocessor.hpp
+++ b/include/glim/preprocess/cloud_preprocessor.hpp
@@ -20,11 +20,11 @@ public:
 public:
   double distance_near_thresh;        ///< Minimum distance threshold
   double distance_far_thresh;         ///< Maximum distance threshold
-  bool global_shutter;                ///< Assume all points in a scan are takes at the same moment and replace per-point timestamps with zero (disable deskewing)
+  bool global_shutter;                ///< Assume all points in a scan are taken at the same moment and replace per-point timestamps with zero (disable deskewing)
   bool use_random_grid_downsampling;  ///< If true, use random grid downsampling, otherwise, use the conventional voxel grid
   double downsample_resolution;       ///< Downsampling resolution
   int downsample_target;              ///< Target number of points for downsampling
-  double downsample_rate;             ///< Downsamping rate (used for random grid downsampling)
+  double downsample_rate;             ///< Downsampling rate (used for random grid downsampling)
   bool enable_outlier_removal;        ///< If true, apply statistical outlier removal
   int outlier_removal_k;              ///< Number of neighbors used for outlier removal
   double outlier_std_mul_factor;      ///< Statistical outlier removal std dev threshold multiplication factor

--- a/include/glim/util/convert_to_string.hpp
+++ b/include/glim/util/convert_to_string.hpp
@@ -8,7 +8,7 @@
 
 namespace glim {
 
-// Convertion to string
+// Conversion to string
 
 template <typename T>
 std::string convert_to_string(const T& value) {

--- a/include/glim/util/interpolation_helper.hpp
+++ b/include/glim/util/interpolation_helper.hpp
@@ -29,7 +29,7 @@ public:
   InterpolationHelper(InterpolationHelperSearchMode search_mode = InterpolationHelperSearchMode::LINEAR) : search_mode(search_mode) {}
   ~InterpolationHelper() {}
 
-  /// @brief Check if it's emptry.
+  /// @brief Check if it's empty.
   bool empty() const { return values.empty(); }
 
   /// @brief Number of queued values.
@@ -62,7 +62,7 @@ public:
   /// @param left_ptr             [out] The closest value that is older than the target timestamp (nullptr if not needed)
   /// @param right_ptr            [out] The closest value that is newer than the target timestamp (nullptr if not needed)
   /// @param remove_cursor_ptr    [out] The index of the value that is older than the left_ptr    (nullptr if not needed)
-  /// @return                     Seach result status
+  /// @return                     Search result status
   InterpolationHelperResult find(const double stamp, StampedValue* left_ptr, StampedValue* right_ptr, int* remove_cursor_ptr) const {
     if (values.empty() || values.back().first < stamp) {
       return InterpolationHelperResult::WAITING;

--- a/include/glim/util/time_keeper.hpp
+++ b/include/glim/util/time_keeper.hpp
@@ -13,7 +13,7 @@ public:
 
   bool autoconf;       ///< If true, load parameters from config file
   bool relative_time;  ///< If true, per-point timestamps are relative to the first point. Otherwise, absolute.
-  /// @brief If true, frame timestamp will never be overwritten by antyhing.
+  /// @brief If true, frame timestamp will never be overwritten by anything.
   ///        If false,
   ///          when per-point timestamps are absolute, overwrite the frame timestamp with the first point timestamp.
   ///          when per-point timestamps are relative and negative, add an offset to the frame timestamp to make per-point ones positive.
@@ -22,7 +22,7 @@ public:
 };
 
 /**
- * @brief Utility class to unify timestamp convension
+ * @brief Utility class to unify timestamp convention
  */
 class TimeKeeper {
 public:

--- a/src/glim/util/serialization.cpp
+++ b/src/glim/util/serialization.cpp
@@ -20,7 +20,7 @@ void serializeToBinaryFile(const gtsam::NonlinearFactorGraph& graph, const std::
     }
   }
 
-  spdlog::warn("retyring to serialize factor graph with only serializable factor types");
+  spdlog::warn("retrying to serialize factor graph with only serializable factor types");
 
   gtsam::NonlinearFactorGraph ser;
   for (const auto& factor : graph) {
@@ -48,7 +48,7 @@ void serializeToBinaryFile(const gtsam::Values& values, const std::string& path,
     }
   }
 
-  spdlog::warn("retyring to serialize values with only serializable value types");
+  spdlog::warn("retrying to serialize values with only serializable value types");
 
   gtsam::Values ser;
   for (const auto& value : values) {

--- a/src/glim/viewer/editor/points_selector.cpp
+++ b/src/glim/viewer/editor/points_selector.cpp
@@ -222,7 +222,7 @@ void PointsSelector::draw_ui() {
   }
 
   // Preferences window
-  if (show_preferences_window && ImGui::Begin("Preferenecs", &show_preferences_window, ImGuiWindowFlags_AlwaysAutoResize)) {
+  if (show_preferences_window && ImGui::Begin("Preferences", &show_preferences_window, ImGuiWindowFlags_AlwaysAutoResize)) {
     ImGui::DragInt("Num threads", &num_threads, 1, 1, std::thread::hardware_concurrency()) || show_note("Number of threads for processing");
 
     ImGui::Separator();
@@ -421,7 +421,7 @@ void PointsSelector::draw_ui() {
         float background_mask_radius = min_cut_params.background_mask_radius;
 
         ImGui::DragFloat("Distance sigma", &distance_sigma, 0.01f, 0.01f, 10.0f);
-        show_note("Disance proximity width [m]");
+        show_note("Distance proximity width [m]");
         ImGui::DragFloat("Angle sigma", &angle_sigma, 0.01f, 0.01f, 180.0f);
         show_note("Angle proximity width [deg]");
         ImGui::DragFloat("Foreground radius", &foreground_mask_radius, 0.01f, 0.01f, 100.0f);
@@ -429,7 +429,7 @@ void PointsSelector::draw_ui() {
         ImGui::DragFloat("Background radius", &background_mask_radius, 0.01f, 0.01f, 100.0f);
         show_note("Points out of this radius are marked as background");
         ImGui::DragInt("K neighbors", &min_cut_params.k_neighbors, 1, 1, 100);
-        show_note("Number of neighbors for mincut graph contruction");
+        show_note("Number of neighbors for mincut graph construction");
 
         min_cut_params.distance_sigma = distance_sigma;
         min_cut_params.angle_sigma = angle_sigma * M_PI / 180.0;
@@ -446,7 +446,7 @@ void PointsSelector::draw_ui() {
         ImGui::DragFloat("Angle threshold", &angle_threshold, 0.01f, 0.01f, 180.0f);
         show_note("Points connection angle threshold [deg]");
         ImGui::DragFloat("Dilation radius", &dilation_radius, 0.01f, 0.01f, 100.0f);
-        show_note("After performing region growing, the extracted region will be dilated by this radius to fill halls");
+        show_note("After performing region growing, the extracted region will be dilated by this radius to fill holes");
 
         region_growing_params.distance_threshold = distance_threshold;
         region_growing_params.angle_threshold = angle_threshold * M_PI / 180.0;

--- a/src/glim/viewer/interactive/bundle_adjustment_modal.cpp
+++ b/src/glim/viewer/interactive/bundle_adjustment_modal.cpp
@@ -84,7 +84,7 @@ gtsam::NonlinearFactor::shared_ptr BundleAdjustmentModal::run() {
 
     if (submaps.size() < 2) {
       ImGui::Text("The number of selected submaps is smaller than 2!!");
-      ImGui::Text("Close this modal an reselect a point!!");
+      ImGui::Text("Close this modal and reselect a point!!");
     }
 
     ImGui::DragFloat("Radius", &radius, 0.01f, min_radius, max_radius);

--- a/src/glim/viewer/interactive_viewer.cpp
+++ b/src/glim/viewer/interactive_viewer.cpp
@@ -210,7 +210,7 @@ void InteractiveViewer::drawable_selection() {
   if (ImGui::Combo("ColorMode", &color_mode, color_modes.data(), color_modes.size())) {
     update_viewer();
   }
-  show_note("Color mode for rendering submaps.\n- RAINBOW=Altitute encoding color\n- INTENSITY=Point intensity\n- SESSION=Session ID");
+  show_note("Color mode for rendering submaps.\n- RAINBOW=Altitude encoding color\n- INTENSITY=Point intensity\n- SESSION=Session ID");
 
   ImGui::Checkbox("Trajectory", &draw_traj);
   ImGui::SameLine();


### PR DESCRIPTION
Hi! While reading through the code I noticed a few small English typos,
so I fixed them here.

The changes only touch comments, documentation, and some log/GUI strings.
No identifiers, public APIs, config keys, or serialization formats are
changed, so the behavior stays the same.

If any of these were intentional, feel free to drop them. Thanks!
