### PR TITLE
fix build with fmt >= 11

### DIFF
--- a/src/glim/odometry/odometry_estimation_ct.cpp
+++ b/src/glim/odometry/odometry_estimation_ct.cpp
@@ -127,7 +127,7 @@ EstimationFrame::ConstPtr OdometryEstimationCT::insert_frame(const PreprocessedF
     gtsam::Vector6 last_twist = gtsam::Vector6::Zero();
     if (current >= 2) {
       if (!frames[last] || !frames[last - 1]) {
-        logger->warn("neither frames[last]={} nor frames[last - 1]={} is released!!", fmt::ptr(frames[last]), fmt::ptr(frames[last - 1]));
+        logger->warn("neither frames[last]={} nor frames[last - 1]={} is released!!", fmt::ptr(frames[last].get()), fmt::ptr(frames[last - 1].get()));
         logger->warn("there might be a large time gap between point cloud frames");
       } else {
         const double delta_time = (frames[last]->stamp + frames[last]->frame->times[frames[last]->frame->size() - 1]) - frames[last - 1]->stamp;


### PR DESCRIPTION
Closes #326 .

`src/glim/odometry/odometry_estimation_ct.cpp:130` passes `std::shared_ptr` directly to `fmt::ptr()`. fmt 11 removed the `std::shared_ptr` and `std::unique_ptr` overloads of `fmt::ptr`, so the call now selects the generic `ptr(T)` template and trips its `is_pointer` static assert:

```
error: static assertion failed: fmt::ptr used with non-pointer
error: no matching function for call to 'bit_cast<const void*>(std::shared_ptr<glim::EstimationFrame>&)'
```

This affects anyone building outside the Ubuntu apt versions, which in my case is a conda/pixi environment, where conda-forge currently ships fmt 12.1.0.

The small change is completely version agnostic and works on previous versions of fmt identically.

The library builds completely with this single line changed, so it appears to be the only fmt >= 11 incompatibility reachable in that configuration.
